### PR TITLE
github actionsの内容修正

### DIFF
--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -5,10 +5,7 @@ on:
     branches:
       - main
   repository_dispatch:
-    types:
-      - update_post
-    branches:
-      - main
+    types: [update_post]
 
 jobs:
   vercel:


### PR DESCRIPTION
##  概要
microcmsで記事を更新してもgithub actionsが動かなかったので設定の見直し

## やったこと
- types を[]で囲む
- default branchで実行されることは自明なのでブランチの指定を削除
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch

## 懸念
動作確認できていないのでpushして行う