### PR TITLE
github actionsに環境変数を設定する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   vercel:
     runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
     name: 'Deploy front-end'
 
     steps:


### PR DESCRIPTION
## 概要
github actions実行時に `pages/archives/tags/[...params].tsx#getTags` で flatMap of undefinedで落ちていることから、環境変数が設定できておらずコンテンツがfetchできていないと判断し、github actionsにmicroCMSのAPI KEYを設定する。

本repositoryのsecretsに定義した環境変数を読み込むようにする

## 参考資料
- 落ちているactions
  - https://github.com/dak2/kdevlog/runs/6226181521?check_suite_focus=true 
- github actionsに環境変数を設定する
  - https://btj0.com/blog/github/use-env/