### PR TITLE
vercelへのデプロイ方法を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,5 +27,10 @@ jobs:
           npm install
           npm run build
       - name: 'Deploy to Vercel'
-        shell: bash
-        run: npm run deploy
+        uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-args: '--prod'
+          vercel-org-id: ${{ secrets.ORG_ID }}
+          vercel-project-id: ${{ secrets.PROJECT_ID }}
+          working-directory: ./


### PR DESCRIPTION
## 概要

https://github.com/dak2/kdevlog/pull/6 の対応以降、[vercelのデプロイがこけている](https://github.com/dak2/kdevlog/runs/6226692814?check_suite_focus=true)

下記のエラーメッセージが出ていることから、環境変数が足りないと判断し環境変数を渡すように変更。

```
Vercel CLI 24.1.0
Error! No existing credentials found. Please run `vercel login` or pass "--token"
Learn More: https://err.sh/vercel/no-credentials-found
```

その際、https://github.com/amondnet/vercel-action#github-actions のactionを利用してデプロイするようにした

## 参考資料
- vercel deploy用のアクション
  - https://github.com/amondnet/vercel-action#github-actions
- ORG_ID / PROJECT_IDの設置場所
  - https://github.com/vercel/vercel/discussions/4367#discussioncomment-1672222
