### PR TITLE
更新日の降順で記事を並び替える

### DIFF
--- a/components/atoms/date.tsx
+++ b/components/atoms/date.tsx
@@ -2,7 +2,7 @@ import { parseISO, format } from 'date-fns';
 
 export function FormatedDate({ dateString }) {
   const date = parseISO(dateString);
-  return <p>{format(date, 'yyyy-MM-dd')}</p>;
+  return format(date, 'yyyy-MM-dd');
 }
 
 export function FormatedToday({ date }) {

--- a/components/atoms/date.tsx
+++ b/components/atoms/date.tsx
@@ -2,7 +2,7 @@ import { parseISO, format } from 'date-fns';
 
 export function FormatedDate({ dateString }) {
   const date = parseISO(dateString);
-  return format(date, 'yyyy-MM-dd');
+  return <p>updated_at: {format(date, 'yyyy-MM-dd')}</p>;
 }
 
 export function FormatedToday({ date }) {

--- a/components/atoms/date.tsx
+++ b/components/atoms/date.tsx
@@ -1,6 +1,6 @@
 import { parseISO, format } from 'date-fns';
 
-export function FormatedCreatedAt({ dateString }) {
+export function FormatedDate({ dateString }) {
   const date = parseISO(dateString);
   return <p>{format(date, 'yyyy-MM-dd')}</p>;
 }

--- a/pages/archives/tags/[...params].tsx
+++ b/pages/archives/tags/[...params].tsx
@@ -33,9 +33,7 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <p>
-                  updated_at: <FormatedDate dateString={updatedAt} />
-                </p>
+                  <FormatedDate dateString={updatedAt} />
               </small>
               <div>
                 <ul>

--- a/pages/archives/tags/[...params].tsx
+++ b/pages/archives/tags/[...params].tsx
@@ -33,7 +33,9 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <FormatedDate dateString={updatedAt} />
+                <p>
+                  updated_at: <FormatedDate dateString={updatedAt} />
+                </p>
               </small>
               <div>
                 <ul>

--- a/pages/archives/tags/[...params].tsx
+++ b/pages/archives/tags/[...params].tsx
@@ -3,13 +3,13 @@ import { httpRequest } from '../../../lib/api';
 import Link from 'next/link';
 import { CMS_API_KEY, CMS_URL } from '../../../lib/const';
 import Head from 'next/head';
-import { FormatedCreatedAt } from '../../../components/atoms/date';
+import { FormatedDate } from '../../../components/atoms/date';
 import GenericIcon from '../../../components/atoms/genericIcon';
 import Pagination from '../../../components/molecules/pagination';
 import { PostType } from '../../../lib/type';
 
 type PropsType = {
-  allPosts: PostType[];
+  posts: PostType[];
   tagName: string;
   totalCount: number;
 };
@@ -24,7 +24,7 @@ const postLists = (props: PropsType) => {
         {icon(props.tagName)}
       </div>
       <ul>
-        {props.allPosts.map(({ id, createdAt, title, tags }, postIndex) => (
+        {props.posts.map(({ id, updatedAt, title, tags }, postIndex) => (
           <li key={postIndex}>
             <div className="mb-12">
               <Link href={`/posts/${id}`}>
@@ -33,7 +33,7 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <FormatedCreatedAt dateString={createdAt} />
+                <FormatedDate dateString={updatedAt} />
               </small>
               <div>
                 <ul>
@@ -85,7 +85,7 @@ const noPosts = () => {
 };
 
 export default function Tags(props: PropsType) {
-  if (props.allPosts.length > 0) {
+  if (props.posts.length > 0) {
     return postLists(props);
   } else {
     return noPosts;
@@ -110,12 +110,16 @@ export const getStaticPaths = async () => {
 export const getStaticProps = async (context) => {
   const tag = context.params.params[0];
   const res = await httpRequest(CMS_URL, CMS_API_KEY);
-  const allPosts = await res.contents;
-  const posts = groupedPostsByTag(allPosts, tag);
+  const posts = await res.contents;
+  const postsByTag = groupedPostsByTag(posts, tag);
+  const postsByNewestSorted = postsByTag.sort(
+    (a: { updatedAt: string }, b: { updatedAt: string }) =>
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
 
   return {
     props: {
-      allPosts: posts,
+      posts: postsByNewestSorted,
       tagName: tag,
       revalidate: 60,
       totalCount: res.totalCount,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,9 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <FormatedDate dateString={updatedAt} />
+                <p>
+                  updated_at: <FormatedDate dateString={updatedAt} />
+                </p>
               </small>
               <div>
                 <ul>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,12 +3,12 @@ import Layout, { siteTitle } from '../components/molecules/layout';
 import { httpRequest } from '../lib/api';
 import { CMS_API_KEY, CMS_URL } from '../lib/const';
 import Link from 'next/link';
-import { FormatedCreatedAt } from '../components/atoms/date';
+import { FormatedDate } from '../components/atoms/date';
 import Pagination from '../components/molecules/pagination';
 import { PostType } from '../lib/type';
 
 type PropsType = {
-  allPosts: PostType[];
+  posts: PostType[];
   totalCount: number;
 };
 
@@ -19,16 +19,16 @@ const postLists = (props: PropsType) => {
         <title>{siteTitle}</title>
       </Head>
       <ul>
-        {props.allPosts.map(({ id, createdAt, title, tags }, postIndex) => (
+        {props.posts.map(({ id, updatedAt, title, tags }, postIndex) => (
           <li key={postIndex}>
             <div className="mb-12">
               <Link href={`/posts/${id}`}>
-                <h2 className="cursor-pointer text-2xl font-extrabold mb-2 text-darkorange dark:text-yellow-300">
+                <h2 className="mb-2 text-2xl font-extrabold cursor-pointer text-darkorange dark:text-yellow-300">
                   <a>{title}</a>
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <FormatedCreatedAt dateString={createdAt} />
+                <FormatedDate dateString={updatedAt} />
               </small>
               <div>
                 <ul>
@@ -44,7 +44,7 @@ const postLists = (props: PropsType) => {
                           },
                         }}
                       >
-                        <p className="cursor-pointer p-1 text-sm mr-2 text-white bg-gray-500 rounded-md font-bold">
+                        <p className="p-1 mr-2 text-sm font-bold text-white bg-gray-500 cursor-pointer rounded-md">
                           {tag.name}
                         </p>
                       </Link>
@@ -67,15 +67,15 @@ const noPosts = () => {
       <Head>
         <title>{siteTitle}</title>
       </Head>
-      <div className="grid justify-items-center pt-64">
-        <h1 className="text-5xl mb-10 font-bold">記事はありません</h1>
+      <div className="pt-64 grid justify-items-center">
+        <h1 className="mb-10 text-5xl font-bold">記事はありません</h1>
       </div>
     </Layout>
   );
 };
 
 export default function Home(props: PropsType) {
-  if (props.allPosts.length > 0) {
+  if (props.posts.length > 0) {
     return postLists(props);
   } else {
     return noPosts;
@@ -84,11 +84,15 @@ export default function Home(props: PropsType) {
 
 export const getStaticProps = async () => {
   const res = await httpRequest(CMS_URL, CMS_API_KEY);
-  const data = await res.contents;
+  const contents = await res.contents;
+  const postsByNewestSorted = contents.sort(
+    (a: { updatedAt: string }, b: { updatedAt: string }) =>
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
 
   return {
     props: {
-      allPosts: data,
+      posts: postsByNewestSorted,
       revalidate: 60,
       totalCount: res.totalCount,
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,9 +28,7 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <p>
-                  updated_at: <FormatedDate dateString={updatedAt} />
-                </p>
+                <FormatedDate dateString={updatedAt} />
               </small>
               <div>
                 <ul>

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -2,7 +2,7 @@ import Layout from '../../components/molecules/layout';
 import { httpRequest } from '../../lib/api';
 import { CMS_API_KEY, CMS_URL } from '../../lib/const';
 import Head from 'next/head';
-import { FormatedCreatedAt } from '../../components/atoms/date';
+import { FormatedDate } from '../../components/atoms/date';
 import marked from 'marked';
 import hljs, { registLanguage } from '../../lib/myHighlight';
 import 'highlight.js/styles/ocean.css';
@@ -31,7 +31,7 @@ const postDetail = (post: PostType) => {
           {post.title}
         </h1>
         <div className="text-gray-400 dark:text-gray-200">
-          <FormatedCreatedAt dateString={post.createdAt} />
+          <FormatedDate dateString={post.updatedAt} />
         </div>
         <div
           className="unreset"

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -31,7 +31,9 @@ const postDetail = (post: PostType) => {
           {post.title}
         </h1>
         <div className="text-gray-400 dark:text-gray-200">
-          <FormatedDate dateString={post.updatedAt} />
+          <p>
+            updated_at: <FormatedDate dateString={post.updatedAt} />
+          </p>
         </div>
         <div
           className="unreset"

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -31,9 +31,7 @@ const postDetail = (post: PostType) => {
           {post.title}
         </h1>
         <div className="text-gray-400 dark:text-gray-200">
-          <p>
-            updated_at: <FormatedDate dateString={post.updatedAt} />
-          </p>
+          <FormatedDate dateString={post.updatedAt} />
         </div>
         <div
           className="unreset"

--- a/pages/posts/page/[id].tsx
+++ b/pages/posts/page/[id].tsx
@@ -2,14 +2,14 @@ import Link from 'next/link';
 import Head from 'next/head';
 import Layout, { siteTitle } from '../../../components/molecules/layout';
 import Pagination from '../../../components/molecules/pagination';
-import { FormatedCreatedAt } from '../../../components/atoms/date';
+import { FormatedDate } from '../../../components/atoms/date';
 import { httpRequest } from '../../../lib/api';
 import { CMS_API_KEY, CMS_URL } from '../../../lib/const';
 import { range, PER_PAGE } from '../../../lib/const';
 import { PostType } from '../../../lib/type';
 
 type PropsType = {
-  allPosts: PostType[];
+  posts: PostType[];
   totalCount: number;
 };
 
@@ -20,7 +20,7 @@ const postLists = (props: PropsType) => {
         <title>{siteTitle}</title>
       </Head>
       <ul>
-        {props.allPosts.map(({ id, createdAt, title, tags }, postIndex) => (
+        {props.posts.map(({ id, updatedAt, title, tags }, postIndex) => (
           <li key={postIndex}>
             <div className="mb-12">
               <Link href={`/posts/${id}`}>
@@ -29,7 +29,7 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <FormatedCreatedAt dateString={createdAt} />
+                <FormatedDate dateString={updatedAt} />
               </small>
               <div>
                 <ul>
@@ -76,7 +76,7 @@ const noPosts = () => {
 };
 
 export default function PostsPageId(props: PropsType) {
-  if (props.allPosts.length > 0) {
+  if (props.posts.length > 0) {
     return postLists(props);
   } else {
     return noPosts;
@@ -99,10 +99,14 @@ export const getStaticProps = async (context) => {
     CMS_API_KEY,
   );
   const posts = await res;
+  const postsByNewestSorted = posts.contents.sort(
+    (a: { updatedAt: string }, b: { updatedAt: string }) =>
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
 
   return {
     props: {
-      allPosts: posts.contents,
+      posts: postsByNewestSorted,
       totalCount: posts.totalCount,
     },
   };

--- a/pages/posts/page/[id].tsx
+++ b/pages/posts/page/[id].tsx
@@ -29,9 +29,7 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <p>
-                  updated_at: <FormatedDate dateString={updatedAt} />
-                </p>
+                <FormatedDate dateString={updatedAt} />
               </small>
               <div>
                 <ul>

--- a/pages/posts/page/[id].tsx
+++ b/pages/posts/page/[id].tsx
@@ -29,7 +29,9 @@ const postLists = (props: PropsType) => {
                 </h2>
               </Link>
               <small className="text-gray-500 dark:text-gray-200">
-                <FormatedDate dateString={updatedAt} />
+                <p>
+                  updated_at: <FormatedDate dateString={updatedAt} />
+                </p>
               </small>
               <div>
                 <ul>


### PR DESCRIPTION
## 概要
タイトルの通り

## やったこと
- updatedAtの降順でソート
- 作成日ではなく更新日を表示する
- 変数名変更